### PR TITLE
Refactored SWC import to read entire streams before processing

### DIFF
--- a/jacs2-commonweb/src/main/java/org/janelia/jacs2/app/AbstractServicesApp.java
+++ b/jacs2-commonweb/src/main/java/org/janelia/jacs2/app/AbstractServicesApp.java
@@ -1,20 +1,14 @@
 package org.janelia.jacs2.app;
 
-import com.beust.jcommander.JCommander;
-
-import io.undertow.Undertow;
-import org.janelia.jacs2.app.undertow.UndertowAppContainer;
-import org.janelia.jacs2.cdi.ApplicationConfigProvider;
-import org.janelia.jacs2.config.ApplicationConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.core.Application;
-
 import java.util.EventListener;
 import java.util.List;
 
-import static io.undertow.servlet.Servlets.servlet;
+import javax.ws.rs.core.Application;
+
+import com.beust.jcommander.JCommander;
+import org.janelia.jacs2.app.undertow.UndertowAppContainer;
+import org.janelia.jacs2.cdi.ApplicationConfigProvider;
+import org.janelia.jacs2.config.ApplicationConfig;
 
 /**
  * This is the bootstrap application for JACS services.

--- a/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCData.java
+++ b/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCData.java
@@ -45,7 +45,7 @@ public class SWCData {
     private static final String NAME_HEADER_PREFIX = "NAME";
     private static final String COLOR_HEADER_PREFIX = "COLOR";
 
-    private String swcFilepath;
+    private final String swcFilepath;
     private List<SWCNode> nodeList = new ArrayList<>();
     private List<String> headerList = new ArrayList<>();
 
@@ -55,6 +55,10 @@ public class SWCData {
 
     SWCData(String swcFilepath) {
         this.swcFilepath = swcFilepath;
+    }
+
+    String getSwcFilepath() {
+        return swcFilepath;
     }
 
     void addHeader(String header) {

--- a/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCReader.java
+++ b/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCReader.java
@@ -13,12 +13,17 @@ public class SWCReader {
     private static final Logger LOG = LoggerFactory.getLogger(SWCReader.class);
 
     SWCData readSWCStream(String name, InputStream swcStream) {
+        if (swcStream == null) {
+            throw new IllegalArgumentException("Null SWC stream for " + name);
+        }
         SWCData swcData = new SWCData(name);
         try {
+            long startTime = System.currentTimeMillis();
+            LOG.debug("Read {} from the SWC stream", name);
             BufferedReader reader = new BufferedReader(new InputStreamReader(swcStream, Charset.defaultCharset()));
             reader.lines()
-                    .map(l -> l.trim())
-                    .filter(l -> l.length() > 0)
+                    .map(String::trim)
+                    .filter(l -> !l.isEmpty())
                     .forEach(l -> {
                         if (l.startsWith("#")) {
                             swcData.addHeader(l);
@@ -27,6 +32,7 @@ public class SWCReader {
                             if (swcNode != null) swcData.addNode(swcNode);
                         }
                     });
+            LOG.debug("Parsed {} in {}secs", name, (System.currentTimeMillis() - startTime) / 1000.);
             return swcData;
         } catch (Exception e) {
             LOG.error("Error parsing SWC stream {}", name, e);

--- a/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCService.java
+++ b/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCService.java
@@ -449,7 +449,7 @@ public class SWCService {
                     // just in case some folders got through - ignore them
                     if (currentEntry == null) {
                         // nothing left in the current stream -> close it
-                        LOG.info("Finished processing {} entries from {}", currentInputStream.archiveEntriesCount, currentInputStream.getStreamName());
+                        LOG.info("Finished retrieving {} entries from {}", currentInputStream.archiveEntriesCount, currentInputStream.getStreamName());
                         currentInputStream.close();
                         // and try to get the next batch
                         archiveInputStreamStack.pop();
@@ -480,7 +480,7 @@ public class SWCService {
                             }
                         } // otherwise continue processing entries from the parent because the parent was an archive
                     } else {
-                        LOG.debug("{}. Process {} from {}", totalEntriesCount.get(), currentEntry.getName(), currentInputStream.getStreamName());
+                        LOG.debug("{}. Retrieve {} from {}", totalEntriesCount.get(), currentEntry.getName(), currentInputStream.getStreamName());
                         InputStream entryStream = currentInputStream.getCurrentEntryStream(currentEntry);
                         ArchiveInputStreamPosition archiveEntryStream = prepareStreamIfArchive(
                                 currentInputStream.getStreamName() + ":" + currentEntry.getName(),
@@ -490,14 +490,14 @@ public class SWCService {
                             // the current entry is a zip or tar
                             archiveInputStreamStack.push(archiveEntryStream);
                         } else {
-                            // this is a regular entry => process it
+                            // this is a regular entry => consume it
                             NamedData<InputStream> entryData = new NamedData<>(currentEntry.getName(), entryStream);
                             action.accept(entryData);
                             long entriesProcessed = totalEntriesCount.incrementAndGet();
                             if (maxSize <= 0 || entriesProcessed < maxSize) {
                                 return true;
                             } else {
-                                LOG.info("Finished importing {} from {}", entriesProcessed, currentInputStream.getStreamName());
+                                LOG.info("Finished retrieving {} from {}", entriesProcessed, currentInputStream.getStreamName());
                                 // close all stacks
                                 for (ArchiveInputStreamPosition as = archiveInputStreamStack.pop(); as != null; as = archiveInputStreamStack.pop()) {
                                     as.close();

--- a/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCService.java
+++ b/jacs2-services/src/main/java/org/janelia/jacs2/dataservice/swc/SWCService.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -257,6 +258,7 @@ public class SWCService {
                                        boolean appendToExisting,
                                        Map<String, Object> storageAttributes) {
         List<SWCData> swcDataList = getRemoteSWCData(swcFolderName, firstEntry, maxSize, getBatchSize, depth, orderSWCs, storageAttributes);
+        LOG.info("Read {} SWC files from {}", swcDataList.size(), swcFolderName);
         VectorOperator externalToInternalConverter = getExternalToInternalConverter(tmSample);
         List<BoundingBox3d> boundingBoxes = swcDataList.stream()
                 .map(swcDataEntry -> {
@@ -331,7 +333,7 @@ public class SWCService {
                 })
                 .orElseGet(Stream::of)
                 .map(swcEntry -> swcReader.readSWCStream(swcEntry.getName(), swcEntry.getData()))
-                .filter(swcData -> swcData != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
S3 streams are extremely sensitive to timeout - if persisting the data pauses the SWC reading and this is reading from S3, the S3 stream will be closed. To avoid this - I read the entire stream in memory (it also parses the SWC because parsing is fast) and only when it's done reading it persists the corresponding tmNeurons into the db.